### PR TITLE
fix: return 404 instead of 500 when project is not found

### DIFF
--- a/src/main/java/faang/school/projectservice/controller/ProjectController.java
+++ b/src/main/java/faang/school/projectservice/controller/ProjectController.java
@@ -4,13 +4,12 @@ import faang.school.projectservice.dto.filter.ProjectFilterDto;
 import faang.school.projectservice.dto.project.ProjectDto;
 
 import java.util.List;
-import java.util.Optional;
 
 import faang.school.projectservice.exception.DataValidationException;
 import faang.school.projectservice.service.ProjectService;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.util.ObjectUtils;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,8 +29,7 @@ public class ProjectController {
     @PostMapping
     public ProjectDto createProject(@RequestBody ProjectDto projectDto, @RequestParam(name = "ownerId") Long ownerId) {
         validateParameters(projectDto);
-        return projectService.createProject( projectDto, ownerId );
-
+        return projectService.createProject(projectDto, ownerId);
     }
 
     @PutMapping("/{projectId}")
@@ -39,7 +37,7 @@ public class ProjectController {
                                     @RequestBody ProjectDto projectDto,
                                     @RequestParam(name = "requestUserId") long requestUserId) {
         validateParameters(projectDto);
-        return projectService.updateProject( projectId, projectDto, requestUserId );
+        return projectService.updateProject(projectId, projectDto, requestUserId);
     }
 
     @GetMapping
@@ -51,24 +49,26 @@ public class ProjectController {
 
     @GetMapping("/all")
     public List<ProjectDto> getAllProjects(@RequestParam long requestUserId) {
-        return projectService.getAllProjects( requestUserId );
+        return projectService.getAllProjects(requestUserId);
     }
 
     @GetMapping("/{projectId}")
-    public ProjectDto getProjectById(@PathVariable long projectId, @RequestParam long requestUserId) {
-        return projectService.getProjectById( projectId, requestUserId );
+    public ProjectDto getProject(@PathVariable @Positive(message = "Project ID must be positive") long projectId,
+                                 @RequestParam long requestUserId
+    ) {
+        return projectService.getProject(projectId, requestUserId);
     }
 
     private void validateParameters(ProjectFilterDto filters) {
-        if (ObjectUtils.isEmpty(filters) || (filters.getNamePattern()==null && filters.getStatusPattern() == null)) {
+        if (ObjectUtils.isEmpty(filters) || (filters.getNamePattern() == null && filters.getStatusPattern() == null)) {
             throw new DataValidationException("Filters  must not be empty");
         }
     }
+
     private void validateParameters(ProjectDto projectDto) {
-        if (projectDto == null  || projectDto.getName() == null || projectDto.getDescription() == null ) {
+        if (projectDto == null || projectDto.getName() == null || projectDto.getDescription() == null) {
             throw new DataValidationException("Project name and description must not be empty");
         }
     }
-
 
 }

--- a/src/main/java/faang/school/projectservice/handler/ErrorResponse.java
+++ b/src/main/java/faang/school/projectservice/handler/ErrorResponse.java
@@ -1,4 +1,4 @@
-package faang.school.projectservice.exception.handler;
+package faang.school.projectservice.handler;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;

--- a/src/main/java/faang/school/projectservice/handler/GlobalExceptionHandler.java
+++ b/src/main/java/faang/school/projectservice/handler/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package faang.school.projectservice.exception.handler;
+package faang.school.projectservice.handler;
 
 import faang.school.projectservice.exception.ConstraintViolation;
 import faang.school.projectservice.exception.DataAccessException;
@@ -7,8 +7,10 @@ import faang.school.projectservice.exception.FileException;
 import faang.school.projectservice.exception.ProjectStatusException;
 import faang.school.projectservice.exception.SizeExceeded;
 import faang.school.projectservice.exception.TeamMemberNotFoundException;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -63,6 +66,17 @@ public class GlobalExceptionHandler {
         return new ErrorResponse(request.getRequestURI(), HttpStatus.NOT_FOUND, e.getMessage());
     }
 
+    @ExceptionHandler
+    public ProblemDetail handleEntityNotFoundException(EntityNotFoundException ex, HttpServletRequest request) {
+        ProblemDetail problem = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+
+        problem.setTitle("Entity not found");
+        problem.setDetail(ex.getMessage());
+        problem.setProperty("exception", ex.getClass().getSimpleName());
+        problem.setInstance(URI.create(request.getRequestURI()));
+
+        return problem;
+    }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Object> handleValidationExceptions(MethodArgumentNotValidException e) {

--- a/src/main/java/faang/school/projectservice/service/ProjectService.java
+++ b/src/main/java/faang/school/projectservice/service/ProjectService.java
@@ -14,6 +14,7 @@ import faang.school.projectservice.validator.ProjectValidator;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -21,18 +22,17 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.stream.Stream;
 
-@Service
+@Slf4j
 @RequiredArgsConstructor
+@Service
 public class ProjectService {
     private final ProjectJpaRepository projectJpaRepository;
     private final ProjectMapper projectMapper;
     private final ProjectValidator projectValidator;
-
+    private final ProjectEventPublisher projectEventPublisher;
+    private final List<ProjectFilter> projectFilters;
     @Value("#{new java.math.BigInteger('${storage.max_capacity}')}")
     private BigInteger maxCapacity;
-    private final ProjectEventPublisher projectEventPublisher;
-
-    private final List<ProjectFilter> projectFilters;
 
     public ProjectDto createProject(ProjectDto projectDto, long requestUserId) {
         if (projectJpaRepository.existsByOwnerIdAndName(requestUserId, projectDto.getName())) {
@@ -50,7 +50,7 @@ public class ProjectService {
     }
 
     public ProjectDto updateProject(long projectId, ProjectDto projectDto, long requestUserId) {
-        Project existingProject = findProjectOrThrowException(projectId);
+        Project existingProject = findProjectByIdOrThrow(projectId);
 
         projectValidator.checkUserIsMemberOrThrowException(existingProject, requestUserId);
 
@@ -87,24 +87,20 @@ public class ProjectService {
         return projectMapper.toDtoList(projectList);
     }
 
-    public ProjectDto getProjectById(long projectId, long requestUserId) {
-        Project project = findProjectOrThrowException(projectId);
+    public ProjectDto getProject(long projectId, long requestUserId) {
+        Project project = findProjectByIdOrThrow(projectId);
 
         projectValidator.checkUserIsMemberOrThrowException(project, requestUserId);
 
         return projectMapper.toDto(project);
     }
 
-    Project getProjectById(long projectId) {
-        return projectJpaRepository.findById(projectId).orElseThrow(EntityNotFoundException::new);
+    Project getProject(long projectId) {
+        return findProjectByIdOrThrow(projectId);
     }
 
     Project save(Project project) {
         return projectJpaRepository.save(project);
-    }
-
-    private Project findProjectOrThrowException(long projectId) {
-        return projectJpaRepository.findById(projectId).orElseThrow(() -> new EntityNotFoundException("Project with id " + projectId + " does not exist"));
     }
 
     public List<Project> getMomentProjectsEntity(MomentDto momentDto) {
@@ -113,6 +109,14 @@ public class ProjectService {
             throw new DataValidationException("Project does not exist");
         }
         return projectList;
+    }
+
+    private Project findProjectByIdOrThrow(long projectId) {
+        return projectJpaRepository.findById(projectId)
+                .orElseThrow(() -> {
+                    log.warn("Project not found: ID={}", projectId);
+                    return new EntityNotFoundException("Project not found");
+                });
     }
 
 }

--- a/src/main/java/faang/school/projectservice/service/ResourceService.java
+++ b/src/main/java/faang/school/projectservice/service/ResourceService.java
@@ -35,7 +35,7 @@ public class ResourceService {
 
     @Transactional
     public ResourceDto uploadResource(Long projectId, MultipartFile file, long userId) {
-        Project project = projectService.getProjectById(projectId);
+        Project project = projectService.getProject(projectId);
         TeamMember author = resourceValidator.validateForTeamMemberExistence(userId, projectId);
 
         BigInteger newStorageSize = project.getStorageSize().add(BigInteger.valueOf(file.getSize()));

--- a/src/test/java/faang/school/projectservice/SpringContextTest.java
+++ b/src/test/java/faang/school/projectservice/SpringContextTest.java
@@ -12,12 +12,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest(classes = ProjectServiceApplication.class)
 @Testcontainers
-public class SpringContextTest {
+class SpringContextTest {
     @Autowired
     private ApplicationContext applicationContext;
     @Test
     @DisplayName("Spring context test check")
-    public void contextLoads() {
+    void contextLoads() {
         assertNotNull( applicationContext );
     }
 }

--- a/src/test/java/faang/school/projectservice/service/ProjectServiceTest.java
+++ b/src/test/java/faang/school/projectservice/service/ProjectServiceTest.java
@@ -236,7 +236,7 @@ public class ProjectServiceTest {
     public void testFindProjectById_ThrowsExceptionForNonExistingProject() {
         when(projectJpaRepository.findById(1L)).thenReturn(Optional.empty());
 
-        assertThrows( EntityNotFoundException.class, () -> projectService.getProjectById( 1L, anyLong() ) );
+        assertThrows( EntityNotFoundException.class, () -> projectService.getProject( 1L, anyLong() ) );
         verifyNoInteractions(projectMapper);
     }
 

--- a/src/test/java/faang/school/projectservice/service/ResourceServiceTest.java
+++ b/src/test/java/faang/school/projectservice/service/ResourceServiceTest.java
@@ -42,14 +42,14 @@ public class ResourceServiceTest extends SetUpFileForResource {
 
     @Test
     public void testUploadResource_StorageSizeExceeded() {
-        when(projectService.getProjectById(secondProject.getId())).thenReturn(secondProject);
+        when(projectService.getProject(secondProject.getId())).thenReturn(secondProject);
         when(resourceValidator.validateForTeamMemberExistence(userId, projectId)).thenReturn(firstTeamMember);
         assertThrows(SizeExceeded.class, () -> resourceService.uploadResource(projectId, file, userId));
     }
 
     @Test
     public void testUploadResource() {
-        when(projectService.getProjectById(firstProject.getId())).thenReturn(firstProject);
+        when(projectService.getProject(firstProject.getId())).thenReturn(firstProject);
         when(resourceValidator.validateForTeamMemberExistence(userId, projectId)).thenReturn(firstTeamMember);
         when(s3Service.uploadFile(file, folder)).thenReturn(firstResource);
         when(resourceRepository.save(firstResource)).thenReturn(firstResource);


### PR DESCRIPTION
- Added @ExceptionHandler for `EntityNotFoundException` in `GlobalExceptionHandler`
- Now returns `ProblemDetail` with HTTP 404 status and structured error response